### PR TITLE
rm comment for no more failing test

### DIFF
--- a/c4j-systemtest/src/test/de/andrena/c4j/systemtest/unchanged/UnchangedForObjectsSystemTest.java
+++ b/c4j-systemtest/src/test/de/andrena/c4j/systemtest/unchanged/UnchangedForObjectsSystemTest.java
@@ -58,7 +58,6 @@ public class UnchangedForObjectsSystemTest {
 		target.parameter5IsChanged(0, 0, 0, 0, new SetLike());
 	}
 
-	// failing, see https://github.com/C4J-Team/C4J/issues/1
 	@Test(expected = AssertionError.class)
 	public void testParameterArrayIsChanged() {
 		target.parameterArrayIsChanged(new SetLike[] { new SetLike() });


### PR DESCRIPTION
As of commit 310f72e the test testParameterArrayIsChanged is no more
failing. Thus the comment that this test fails can be removed.
